### PR TITLE
Hotfix/db변경대응 progress

### DIFF
--- a/topla-spring/src/main/java/com/yachugak/topla/controller/TaskController.java
+++ b/topla-spring/src/main/java/com/yachugak/topla/controller/TaskController.java
@@ -97,15 +97,22 @@ public class TaskController {
 	@PutMapping("/{uid}/finish")
 	@Transactional(readOnly = false)
 	public String updateProgress(@PathVariable("uid") long uid, @RequestBody CheckAsFinishedRequestFormat req) {
+		// TODO: 나중에 서비스로 내리기.
 		Task updateTarget = taskService.findTaskById(uid);
-		taskService.setProgress(updateTarget, req.getProgress());
-		if(req.getProgress() == 100) {
+		if(req.getProgress() == updateTarget.getEstimatedTime()) {
 			Date time = new Date();
 			taskService.setFinishTime(updateTarget, time);
 		}
 		else {
 			taskService.setFinishTime(updateTarget, null);
 		}
+		
+		int progress = req.getProgress();
+		if(progress < 0) {
+			progress = 0;
+		}
+		taskService.setProgress(updateTarget, progress);
+		
 		return "ok";
 	}
 }

--- a/topla-spring/src/main/java/com/yachugak/topla/entity/Plan.java
+++ b/topla-spring/src/main/java/com/yachugak/topla/entity/Plan.java
@@ -21,6 +21,10 @@ public class Plan {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long uid;
 
+	@ManyToOne
+	@JoinColumn(name="task_uid")
+	private Task task;
+	
 	@Column
 	@Temporal(TemporalType.DATE)
 	private Date doDate;
@@ -28,9 +32,8 @@ public class Plan {
 	@Column
 	private Integer doTime;
 	
-	@ManyToOne
-	@JoinColumn(name="task_uid")
-	private Task task;
+	@Column
+	private Integer progress;
 
 	public Long getUid() {
 		return uid;
@@ -63,4 +66,13 @@ public class Plan {
 	public void setTask(Task task) {
 		this.task = task;
 	}
+
+	public Integer getProgress() {
+		return progress;
+	}
+
+	public void setProgress(Integer progress) {
+		this.progress = progress;
+	}
+	
 }

--- a/topla-spring/src/main/java/com/yachugak/topla/entity/Task.java
+++ b/topla-spring/src/main/java/com/yachugak/topla/entity/Task.java
@@ -23,27 +23,31 @@ public class Task {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long uid;
 	
+	@ManyToOne
+	@JoinColumn(name="user_uid")
+	private User user;
+	
 	@Column
 	private String title;
+
+	@Column
+	private String location;
 	
 	@Column
 	@Temporal(TemporalType.DATE)
 	private Date dueDate;
 	
 	@Column
-	private String location;
-	
-	@Column
 	private Integer priority;
 	
 	@Column
 	private Integer estimatedTime;
+
+	@Column
+	private Integer progress;
 	
 	@Column
 	private Integer realTime;
-	
-	@Column
-	private Integer progress;
 	
 	@Column
 	private String memo;
@@ -58,10 +62,6 @@ public class Task {
 	@Column
 	@Temporal(TemporalType.TIMESTAMP)
 	private Date finishDate;
-	
-	@ManyToOne
-	@JoinColumn(name="user_uid")
-	private User user;
 	
 	@OneToMany(mappedBy = "task")
 	private List<Plan> plans;

--- a/topla-spring/src/main/java/com/yachugak/topla/service/TaskService.java
+++ b/topla-spring/src/main/java/com/yachugak/topla/service/TaskService.java
@@ -95,8 +95,8 @@ public class TaskService {
 	}
 	
 	public void setProgress(Task task, int progress) {
-		if(progress < 0 || progress > 100) {
-			throw new InvalidArgumentException("progress", "0~100", progress+"");
+		if(progress < 0 || progress > task.getEstimatedTime()) {
+			throw new InvalidArgumentException("progress", "0"+task.getEstimatedTime(), progress+"");
 		} 
 		task.setProgress(progress);
 	}
@@ -150,7 +150,8 @@ public class TaskService {
 			throw new InvalidArgumentException("doTime", "0~1440", ""+doTime);
 		}
 		
-		Plan newPlan = new Plan();
+		Plan newPlan = new Plan();		
+		newPlan.setProgress(0);
 		newPlan.setDoDate(doDate);
 		newPlan.setDoTime(doTime);
 		newPlan.setTask(task);

--- a/topla-spring/src/main/java/com/yachugak/topla/service/TaskService.java
+++ b/topla-spring/src/main/java/com/yachugak/topla/service/TaskService.java
@@ -40,9 +40,9 @@ public class TaskService {
 		Task newTask = new Task();
 		this.setTitle(newTask, title);
 		this.setPriority(newTask, priority);
-		this.setProgress(newTask, 0);
-		this.setEstimatedTime(newTask, null);
+		this.setEstimatedTime(newTask, 0);
 		this.setCreatedDate(newTask, new Date());
+		this.setProgress(newTask, 0);
 		taskRepository.saveAndFlush(newTask);
 		
 		return newTask;
@@ -95,6 +95,9 @@ public class TaskService {
 	}
 	
 	public void setProgress(Task task, int progress) {
+		if(task.getEstimatedTime() == null) {
+			throw new InvalidArgumentException("EstimatedTime", "예상시간값", task.getEstimatedTime()+"");
+		}
 		if(progress < 0 || progress > task.getEstimatedTime()) {
 			throw new InvalidArgumentException("progress", "0"+task.getEstimatedTime(), progress+"");
 		} 

--- a/topla-spring/src/test/java/com/yachugak/topla/TaskApiTest.java
+++ b/topla-spring/src/test/java/com/yachugak/topla/TaskApiTest.java
@@ -145,6 +145,7 @@ public class TaskApiTest {
 	@Transactional(readOnly = false)
 	public void uncheckFinishedTask() {
 		Task originialTask = taskService.createNewTask("완료작업 해제테스트", 2);
+		taskService.setEstimatedTime(originialTask, 100);
 		taskService.setProgress(originialTask, 100);
 		Task updateTask = taskRepository.findByTitle("완료작업 해제테스트").get();
 		taskService.setProgress(updateTask, 50);


### PR DESCRIPTION
<문제이유>
TaskService.setProgress에서 progress의 유효성검사를 0~100(백분율)으로 하다가, estimatedTime(분) 값과의 비교로 바꾸었음.

이 과정에서, null 값 허용되어있던 estimated와의 비교.
또한, estimated와의 비교 과정에서, task엔티티 초기화순서가 꼬여서 항상 null 값.
=> nullPointerException 일어남.

<해결방법>
 estimate_time은 null 허용 X. 기본값은 0으로 둠.

<추가사항>
* estimatedTime이 0인경우에는, 
완료시, progress값은 0 만 들어올 수 있음. => finish_date로 완료여부확인
완료해제시, progress값은 -1로 받게합의. -> DB에는 0으로 넣고, finish_date null로 변경.