### PR TITLE
[hotfix] TimeTable에서 할당한 plan을 제거할 때 생기는 버그 수정

### DIFF
--- a/topla-spring/src/main/java/com/yachugak/topla/plan/TimeTable.java
+++ b/topla-spring/src/main/java/com/yachugak/topla/plan/TimeTable.java
@@ -197,10 +197,16 @@ public class TimeTable {
 
 	public void deleteAllUndonTaskItemByTaskId(long uid) {
 		for(Day day : this.days) {
+			ArrayList<TaskItem> removeList = new ArrayList<TaskItem>();
+
 			for(TaskItem ti : day.getTaskItems()) {
 				if(ti.getTaskId() == uid && ti.getPlnaUid() == null) {
-					day.getTaskItems().remove(ti);
+					removeList.add(ti);
 				}
+			}
+
+			for(TaskItem deleteTarget : removeList) {
+				day.getTaskItems().remove(deleteTarget);
 			}
 		}
 	}

--- a/topla-spring/src/test/java/com/yachugak/topla/PlanTest.java
+++ b/topla-spring/src/test/java/com/yachugak/topla/PlanTest.java
@@ -507,6 +507,22 @@ public class PlanTest {
 		assertEquals("ok", res);
 	}
 	
+	//중요도 3작업이 마감일밖으로 나갈 때 기존 할당된 plan을 지우는 상황에서 버그가 나는 상황을 재현
+	@Test
+	public void deleteUnDonePlanOfPriority3Test() {
+		SchedulePresetDataFormat schedulePreset = new SchedulePresetDataFormat();
+		schedulePreset.decode("0240024002400240024002400240");
+		ArrayList<Task> testTaskList = new ArrayList<>();
+		testTaskList.add(makeTask(1L, 3, 300, makeDate(2020,11,28)));
+		
+		Date planStartDate = makeDate(2020, 11, 28);
+
+		Planizer planizer = new Planizer(schedulePreset, testTaskList, planStartDate);
+		TimeTable result = planizer.fractionalBinPackingPlan();
+		
+		assertEquals(0, result.getDay(0).getTaskItems().size());
+	}
+	
 	private boolean dateEqual(Date date1, Date date2) {
 		if(date1.getYear() != date2.getYear()) {
 			return false;


### PR DESCRIPTION
- loop가 돌고 있는데 taskItem을 지운 것이 버그의 원인이었음. 삭제 대상을 list에 축적한 뒤 loop가 끝나고 일괄 삭제함.